### PR TITLE
Delete Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: node app.js


### PR DESCRIPTION
This file overrides the default behaviour of Heroku, which is to run `npm start`. I've successfully deployed [my clone of your app](https://roy-project2-seb.herokuapp.com) to Heroku by simply removing `Procfile`.

**Tip:** Set an environment variable called `DEBUG` to `*` (wildcard) to see a lot more output in Papertrail. (This is not required but sometimes useful to view everything that's going on.)
